### PR TITLE
Fix for TypeError in "x = Pipeline(six.text_type.lower)(x)" for non unicode string

### DIFF
--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -214,7 +214,7 @@ class Field(RawField):
         if self.sequential and isinstance(x, six.text_type):
             x = self.tokenize(x.rstrip('\n'))
         if self.lower:
-            x = Pipeline(six.text_type.lower)(x)
+            x = Pipeline(six.text_type.lower)(six.text_type(x))
         if self.sequential and self.use_vocab and self.stop_words is not None:
             x = [w for w in x if w not in self.stop_words]
         if self.preprocessing is not None:


### PR DESCRIPTION
In case of non unicode string `six.text_type.lower` is throwing exception 

```  File "/Users/atulkumar/anaconda/envs/squad/lib/python2.7/site-packages/torchtext/data/dataset.py", line 78, in splits
    os.path.join(path, train), **kwargs)
  File "/Users/atulkumar/anaconda/envs/squad/lib/python2.7/site-packages/torchtext/datasets/sequence_tagging.py", line 33, in __init__
    examples.append(data.Example.fromlist(columns, fields))
  File "/Users/atulkumar/anaconda/envs/squad/lib/python2.7/site-packages/torchtext/data/example.py", line 50, in fromlist
    setattr(ex, n, f.preprocess(val))
  File "/Users/atulkumar/anaconda/envs/squad/lib/python2.7/site-packages/torchtext/data/field.py", line 181, in preprocess
    x = Pipeline(six.text_type.lower)(x)
  File "/Users/atulkumar/anaconda/envs/squad/lib/python2.7/site-packages/torchtext/data/pipeline.py", line 37, in __call__
    x = pipe.call(x, *args)
  File "/Users/atulkumar/anaconda/envs/squad/lib/python2.7/site-packages/torchtext/data/pipeline.py", line 52, in call
    return [self.convert_token(tok, *args) for tok in x]
TypeError: descriptor 'lower' requires a 'unicode' object but received a 'str'```